### PR TITLE
Transition from uploading images directly to server to uploading directly to database as binary data

### DIFF
--- a/controllers/categoryController.mjs
+++ b/controllers/categoryController.mjs
@@ -46,25 +46,26 @@ async function getEditCategoryForm(req, res) {
 async function postEditCategoryForm(req, res) {
   const id = req.params.id;
 
-  let img_data = '';
-  let img_type = '';
+  let buffer = null;
+  let mimetype = null;
   let { img_data: previous_img_data, img_type: previous_img_type } =
     await db.getCategory(id);
   if (req.file) {
-    img_data = req.file.buffer.toString('base64');
-    img_type = req.file.mimetype;
+    // If a file was added in the form, use it.
+    buffer = req.file.buffer.toString('base64');
+    mimetype = req.file.mimetype;
   } else {
-    // If no new file in req, just re-use old one.
-    img_data = previous_img_data;
-    img_type = previous_img_type;
+    // If no new file in the form, just re-use old one.
+    buffer = previous_img_data;
+    mimetype = previous_img_type;
   }
 
   const { name } = req.body;
   await db.updateCategory(id, {
     id,
     name,
-    img_data,
-    img_type,
+    img_data: buffer,
+    img_type: mimetype,
   });
   res.status(303).redirect(`/category/${id}`);
 }

--- a/controllers/categoryController.mjs
+++ b/controllers/categoryController.mjs
@@ -1,5 +1,4 @@
 import * as db from '../db/queries.mjs';
-import fs from 'node:fs/promises';
 
 async function getCategories(req, res) {
   const categories = await db.getAllCategories();
@@ -27,10 +26,11 @@ async function getNewCategoryForm(req, res) {
 
 async function postNewCategoryForm(req, res) {
   const { name } = req.body;
-  const img_url = req.file.path;
+  const { buffer, mimetype } = req.file;
   const { id } = await db.addCategory({
     name,
-    img_url,
+    img_data: buffer.toString('base64'),
+    img_type: mimetype,
   });
   res.status(303).redirect(`/category/${id}`);
 }
@@ -46,22 +46,25 @@ async function getEditCategoryForm(req, res) {
 async function postEditCategoryForm(req, res) {
   const id = req.params.id;
 
-  let img_url = '';
-  let { img_url: previous_img_url } = await db.getCategory(id);
+  let img_data = '';
+  let img_type = '';
+  let { img_data: previous_img_data, img_type: previous_img_type } =
+    await db.getCategory(id);
   if (req.file) {
-    img_url = req.file.path;
-    // Delete previous logo file if there is a new file to upload.
-    fs.unlink(previous_img_url).catch((error) => console.error(error));
+    img_data = req.file.buffer.toString('base64');
+    img_type = req.file.mimetype;
   } else {
     // If no new file in req, just re-use old one.
-    img_url = previous_img_url;
+    img_data = previous_img_data;
+    img_type = previous_img_type;
   }
 
   const { name } = req.body;
   await db.updateCategory(id, {
     id,
     name,
-    img_url,
+    img_data,
+    img_type,
   });
   res.status(303).redirect(`/category/${id}`);
 }

--- a/controllers/productController.mjs
+++ b/controllers/productController.mjs
@@ -1,4 +1,3 @@
-import fs from 'node:fs/promises';
 import * as db from '../db/queries.mjs';
 
 async function getProducts(req, res) {
@@ -105,17 +104,14 @@ async function deleteProduct(req, res) {
 async function postNewProductImageForm(req, res) {
   const { id } = req.params;
   const { alt_text } = req.body;
-  const { path: img_url } = req.file;
-  await db.addProductImage(id, img_url, alt_text);
+  const { buffer, mimetype } = req.file;
+  await db.addProductImage(id, buffer.toString('base64'), mimetype, alt_text);
   res.status(303).redirect(`/product/${id}`);
 }
 
 async function deleteProductImage(req, res) {
   const { id, image_id } = req.params;
-  // Delete the file.
-  const { img_url } = await db.getProductImage(image_id);
-  fs.unlink(img_url).catch((error) => console.error(error));
-  // Remove the database entry that links to that file.
+  // Remove the database entry that contains the file.
   await db.deleteProductImage(image_id);
   res.status(303).redirect(`/product/${id}`);
 }

--- a/db/populate.js
+++ b/db/populate.js
@@ -7,7 +7,8 @@ const SQL = `
     id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     name VARCHAR ( 255 ) NOT NULL UNIQUE,
     description TEXT,
-    img_url VARCHAR ( 255 )
+    img_data BYTEA,
+    img_type VARCHAR ( 20 )
   );
 
   CREATE TABLE IF NOT EXISTS products (
@@ -22,7 +23,8 @@ const SQL = `
   CREATE TABLE IF NOT EXISTS categories (
     id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     name VARCHAR ( 255 ) NOT NULL UNIQUE,
-    img_url VARCHAR ( 255 ) NOT NULL
+    img_data BYTEA NOT NULL,
+    img_type VARCHAR ( 20 ) NOT NULL
   );
 
   CREATE TABLE IF NOT EXISTS product_categories (
@@ -37,7 +39,8 @@ const SQL = `
   CREATE TABLE IF NOT EXISTS product_images (
     id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     product_id INTEGER REFERENCES products ( id ) ON DELETE CASCADE,
-    img_url VARCHAR ( 255 ) NOT NULL,
+    img_data BYTEA NOT NULL,
+    img_type VARCHAR ( 20 ) NOT NULL,
     alt_text VARCHAR ( 255 ) NOT NULL
   );
 

--- a/db/queries.mjs
+++ b/db/queries.mjs
@@ -93,7 +93,8 @@ async function getAllProductsForManufacturer(id) {
         p.available,
         p.price,
         p.description,
-        pi.img_url,
+        pi.img_data,
+        pi.img_type,
         pi.alt_text
       FROM products AS p
       LEFT JOIN product_images AS pi ON pi.product_id = p.id
@@ -116,19 +117,19 @@ async function getManufacturer(id) {
 }
 
 async function addManufacturer(manufacturer) {
-  const { name, description, img_url } = manufacturer;
+  const { name, description, img_data, img_type } = manufacturer;
   const { rows } = await pool.query(
-    'INSERT INTO manufacturers (name, description, img_url) VALUES ($1, $2, $3) RETURNING *',
-    [name, description, img_url],
+    'INSERT INTO manufacturers (name, description, img_data, img_type) VALUES ($1, $2, $3, $4) RETURNING *',
+    [name, description, img_data, img_type],
   );
   return rows[0];
 }
 
 async function updateManufacturer(id, updates) {
-  const { name, description, img_url } = updates;
+  const { name, description, img_data, img_type } = updates;
   await pool.query(
-    `UPDATE manufacturers SET name = $1, description = $2, img_url = $3 WHERE id = $4`,
-    [name, description, img_url, id],
+    `UPDATE manufacturers SET name = $1, description = $2, img_data = $3, img_type = $4 WHERE id = $5`,
+    [name, description, img_data, img_type, id],
   );
 }
 

--- a/db/queries.mjs
+++ b/db/queries.mjs
@@ -11,7 +11,8 @@ async function getAllProducts() {
         p.available,
         p.price,
         p.description,
-        pi.img_url,
+        pi.img_data,
+        pi.img_type,
         pi.alt_text
       FROM products AS p
       LEFT JOIN product_images AS pi ON pi.product_id = p.id
@@ -29,7 +30,8 @@ async function getProduct(id) {
       p.manufacturer_id,
       m.id AS manufacturer_id,
       m.name AS manufacturer_name,
-      m.img_url AS manufacturer_img_url,
+      m.img_data AS manufacturer_img_data,
+      m.img_type AS manufacturer_img_type,
       p.name,
       p.available,
       p.price,
@@ -271,10 +273,10 @@ async function getAllImagesForProduct(id) {
   return rows;
 }
 
-async function addProductImage(product_id, img_url, alt_text) {
+async function addProductImage(product_id, img_data, img_type, alt_text) {
   const { rows } = await pool.query(
-    'INSERT INTO product_images (product_id, img_url, alt_text) VALUES ($1, $2, $3)',
-    [product_id, img_url, alt_text],
+    'INSERT INTO product_images (product_id, img_data, img_type, alt_text) VALUES ($1, $2, $3, $4)',
+    [product_id, img_data, img_type, alt_text],
   );
   return rows;
 }

--- a/db/queries.mjs
+++ b/db/queries.mjs
@@ -145,19 +145,19 @@ async function getCategory(id) {
 }
 
 async function addCategory(category) {
-  const { name, img_url } = category;
+  const { name, img_data, img_type } = category;
   const { rows } = await pool.query(
-    'INSERT INTO categories (name, img_url) VALUES ($1, $2) RETURNING *',
-    [name, img_url],
+    'INSERT INTO categories (name, img_data, img_type) VALUES ($1, $2, $3) RETURNING *',
+    [name, img_data, img_type],
   );
   return rows[0];
 }
 
 async function updateCategory(id, updates) {
-  const { name, img_url } = updates;
+  const { name, img_data, img_type } = updates;
   await pool.query(
-    'UPDATE categories SET name = $1, img_url = $2 WHERE id = $3',
-    [name, img_url, id],
+    'UPDATE categories SET name = $1, img_data = $2, img_type = $3 WHERE id = $4',
+    [name, img_data, img_type, id],
   );
 }
 
@@ -233,7 +233,8 @@ async function getAllProductsInCategory(id) {
         p.available,
         p.price,
         p.description,
-        pi.img_url,
+        pi.img_data,
+        pi.img_type,
         pi.alt_text,
         pc.category_id
       FROM products AS p

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.1.tgz",
-      "integrity": "sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -865,9 +865,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/routes/categoryRouter.mjs
+++ b/routes/categoryRouter.mjs
@@ -3,19 +3,7 @@ import * as categoryController from '../controllers/categoryController.mjs';
 import multer from 'multer';
 
 const appRouter = Router();
-
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    cb(null, 'uploads/categories');
-  },
-  filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    const fileExtension = file.mimetype.slice(-3);
-    const fileName = file.fieldname + '-' + uniqueSuffix + '.' + fileExtension;
-    cb(null, fileName);
-  },
-});
-const upload = multer({ storage });
+const upload = multer({ storage: multer.memoryStorage() });
 
 appRouter.get('/', categoryController.getCategories);
 appRouter.get('/new', categoryController.getNewCategoryForm);

--- a/routes/manufacturerRouter.mjs
+++ b/routes/manufacturerRouter.mjs
@@ -3,19 +3,7 @@ import * as manufacturerController from '../controllers/manufacturerController.m
 import multer from 'multer';
 
 const appRouter = Router();
-
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    cb(null, 'uploads/manufacturers');
-  },
-  filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    const fileExtension = file.mimetype.slice(-3);
-    const fileName = file.fieldname + '-' + uniqueSuffix + '.' + fileExtension;
-    cb(null, fileName);
-  },
-});
-const upload = multer({ storage });
+const upload = multer({ storage: multer.memoryStorage() });
 
 appRouter.get('/', manufacturerController.getManufacturers);
 appRouter.get('/new', manufacturerController.getNewManufacturerForm);

--- a/routes/productRouter.mjs
+++ b/routes/productRouter.mjs
@@ -3,19 +3,7 @@ import * as productController from '../controllers/productController.mjs';
 import multer from 'multer';
 
 const appRouter = Router();
-
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    cb(null, 'uploads/products');
-  },
-  filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    const fileExtension = file.mimetype.slice(-3);
-    const fileName = file.fieldname + '-' + uniqueSuffix + '.' + fileExtension;
-    cb(null, fileName);
-  },
-});
-const upload = multer({ storage });
+const upload = multer({ storage: multer.memoryStorage() });
 
 appRouter.get('/', productController.getProducts);
 appRouter.get('/new', productController.getNewProductForm);

--- a/views/categories/categoryFormFields.ejs
+++ b/views/categories/categoryFormFields.ejs
@@ -1,4 +1,4 @@
 <label for="name">Name: </label>
 <input type="text" name="name" id="name" required value="<%= locals.category != null ? category.name : '' %>">
 <label for="img">Image: </label>
-<input type="file" name="img" id="img">
+<input type="file" name="img" id="img" required>

--- a/views/categories/categoryListCategory.ejs
+++ b/views/categories/categoryListCategory.ejs
@@ -1,4 +1,8 @@
 <a href="/category/<%= category.id %>">
   <h2><%= category.name %></h2>
-  <img src="/<%= category.img_url || 'public/no_img.png' %>" alt="<%= category.name %> category">
+  <% if (category.img_data != null) { %>
+    <img src="data:<%= category.img_type %>;base64,<%= category.img_data %>" alt="<%= category.name %> category">
+  <% } else { %>
+    <img src="public/no_img.png" alt="<%= category.name %> category">
+  <% } %>
 </a>

--- a/views/manufacturers/manufacturer.ejs
+++ b/views/manufacturers/manufacturer.ejs
@@ -6,7 +6,11 @@
     <div class="container section-top-padding section-bottom-padding">
       <h1><%= manufacturer.name %></h1>
       <div class="manufacturer-header section-bottom-padding">
-        <img src="/<%= manufacturer.img_url || '/public/no_img.png' %>" alt="<%= manufacturer.name %>">
+        <% if (manufacturer.img_data != null) { %>
+          <img src="data:<%= manufacturer.img_type %>;base64,<%= manufacturer.img_data %>" alt="<%= manufacturer.name %>">
+        <% } else { %>
+          <img src="/public/no_img.png" alt="<%= manufacturer.name %>">
+        <% } %>
         <p><%= manufacturer.description %></p>
       </div>
       <h2 class="clear-both">Products</h2>

--- a/views/manufacturers/manufacturerListManufacturer.ejs
+++ b/views/manufacturers/manufacturerListManufacturer.ejs
@@ -1,3 +1,7 @@
 <a href="/manufacturer/<%= manufacturer.id %>">
-  <img src="/<%= manufacturer.img_url %>" alt="<%= manufacturer.name %> logo">
+  <% if (manufacturer.img_data != null) { %>
+    <img src="data:<%= manufacturer.img_type %>;base64,<%= manufacturer.img_data %>" alt="<%= manufacturer.name %>">
+  <% } else { %>
+    <img src="/public/no_img.png" alt="<%= manufacturer.name %>">
+  <% } %>
 </a>

--- a/views/partials/productsGridItem.ejs
+++ b/views/partials/productsGridItem.ejs
@@ -3,5 +3,9 @@
     <h3><%= product.name %></h3>
     £<%= product.price %>
   </div>
-  <img src="/<%= product.img_url || 'public/no_img.png' %>" alt="<%= product.alt_text %>">
+  <% if (product.img_data) { %>
+    <img src="data:<%= product.img_type %>;base64,<%= product.img_data %>" alt="<%= product.alt_text %>">
+  <% } else { %>
+    <img src="public/no_img.png" alt="<%= product.alt_text %>">
+  <% } %>
 </a>

--- a/views/products/product.ejs
+++ b/views/products/product.ejs
@@ -7,7 +7,7 @@
       <div class="product-page__header-bar">
         <h1><%= product.name %></h1>
         <a href="/manufacturer/<%= product.manufacturer_id %>">
-          <img src="/<%= product.manufacturer_img_url %>" alt="Visit <%= product.manufacturer_name %> page">
+          <img src="data:<%= product.manufacturer_img_type %>;base64,<%= product.manufacturer_img_data %>" alt=" Visit <%= product.manufacturer_name %>'s page">
         </a>
       </div>
       <div class="grid product">
@@ -43,11 +43,11 @@
         <div>
           <h2>Images</h2>
           <ul class="list-no-style image-list">
-            <% if (locals.images !=null && images.length> 0) { %>
+            <% if (locals.images != null && images.length> 0) { %>
               <% images.forEach((image) => { %>
                 <li>
                   <h3><%= image.alt_text %></h3>
-                  <img src="/<%= image.img_url %>" alt="<%= image.alt_text %>">
+                  <img src="data:<%= image.img_type %>;base64,<%= image.img_data %>" alt="<%= image.alt_text %>">
                   <form action="/product/<%= product.id %>/image/<%= image.id %>/delete" method="post">
                     <button type="submit">Delete</button>
                   </form>


### PR DESCRIPTION
Uploading images directly to the server does not work on a platform as a service, like adaptable.io, since the service scales up and down as required - it creates and closes instances of the application as required, so any files uploaded wouldn't be persistent.

The proper solution to this is to use a CDN, like Amazon Web Services S3. I looked at using it, and there is a free trial for up to a year, but I didn't want to waste what would probably be my only free trial on a small practice application like this. I will save that for a bigger project.

So instead of that, the image data is uploaded as binary data to the database. This is clearly not the proper way to do it; the database size is going to balloon, pg doesn't know what to do when it tries to display a row of data (the image data displays as a ridiculously long string), you have to also store the file type on the database, getting the image data to load into an <img> tag properly was pretty hard to figure out. Yeah. Clunky.

Just storing the image url in the database is infinitely cleaner and better in every way. But in this instance, doing things the wrong way seemed like the best option.